### PR TITLE
revert: Remove a static four space indent from input

### DIFF
--- a/sections/rst2zsh/completion.rst
+++ b/sections/rst2zsh/completion.rst
@@ -9,6 +9,7 @@ A simple completion to make life a little easier.
 
     _arguments \
         {-d,--depfile}'[File to write dependencies to]:_files' \
+        {-i,--indent}'[Strip leading code block indent]' \
         {-h,--help}'[This message]' \
         '1:input file:_files' \
         '2:output file:_files'

--- a/sections/rst2zsh/main_logic.rst
+++ b/sections/rst2zsh/main_logic.rst
@@ -6,12 +6,13 @@ This section handles command-line argument parsing and the main execution flow.
 .. code:: zsh
 
     typeset -A args
-    zparseopts -D -K -E -A args -M -- d: -depfile:=d h -help=h
+    zparseopts -D -K -E -A args -M -- d: -depfile:=d i -indent=i h -help=h
 
     if [[ -n ${args[(I)-h]} ]] {
         print -P "Usage: %B$0%b [option…] <input> <output>"
         echo "Options:"
         echo "    -d, --depfile <file>          File to write dependencies to"
+        echo "    -i, --indent                  Strip leading code block indent"
         echo "    -h, --help                    This message"
         exit 0
     } elif [[ -z ${1:-} ]] {
@@ -21,6 +22,7 @@ This section handles command-line argument parsing and the main execution flow.
         echo "Error: No output given"
         exit 2
     }
+    DYNAMIC_INDENT=${+args[-i]}
 
 Thanks to :program:`zsh`'s ``-U`` flag we can ignore duplicate includes, and
 simply let :command:`zsh` uniquify our array::

--- a/sections/rst2zsh/parse_function.rst
+++ b/sections/rst2zsh/parse_function.rst
@@ -33,7 +33,6 @@ to :abbr:`reST (reStructuredText)` content when debugging output::
 
 ::
 
-        local indent_prefix=""
         local line match mbegin mend
         while IFS='' read -r line; do
             (( line_nr++ ))
@@ -53,10 +52,6 @@ We'll have indented filenames within toctree_ directive::
                 in_block=1
                 in_toctree=0
 
-Reset indent for the new block::
-
-                indent_prefix=""
-
 Add source map, but not if we're at the very start of a non-recursive call.
 The reason is that this would break the output if first line is a shebang.
 
@@ -72,16 +67,10 @@ When we leave the code block we need to reset our state::
                 in_block=0
                 in_toctree=0
             } elif (( $in_block )) && [[ -n $line ]] {
-                if [[ -z $indent_prefix ]] {
-
-Capture the indentation of the first line of the block::
-
-                    [[ $line =~ '^([[:space:]]+)' ]] && indent_prefix=$match[1]
-                }
 
 Remove the captured indentation prefix from the line::
 
-                echo -E "${line#$indent_prefix}" >> $output
+                echo -E "${line[5,-1]}" >> $output
             }
         done < $input
 


### PR DESCRIPTION
While the reverted change is a closer match to the reST spec, it makes output harder to debug.  I think it might make sense to make this optional, but right now I’m just be happier to see it removed.

This reverts 6940debe3ed7c9f5583a3822b29e334716a524b0.
