### PR TITLE
feat: Automate maintenance of versions table

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -26,6 +26,9 @@ rule sphinx
     $SOURCEDIR $BUILDDIR/$builder
   description = Building $builder
 
+rule versions
+  command = tools/generate_versions $out
+
 build README.html: rst2html README.rst
 build init: rst2zsh init.rst | tools/rst2zsh
 default init
@@ -36,12 +39,13 @@ build tools/rst2zsh: rst2zsh-boot rst2zsh.rst $
   sections/rst2zsh/main_logic.rst
 default tools/rst2zsh
 
-build html: sphinx
+build html: sphinx | sections/river/software_versions.csv
   builder = html
-build linkcheck: sphinx
+build linkcheck: sphinx | sections/river/software_versions.csv
   builder = linkcheck
-build spelling: sphinx
+build spelling: sphinx | sections/river/software_versions.csv
   builder = spelling
 
 build completions/_rst2zsh: rst2zsh sections/rst2zsh/completion.rst | tools/rst2zsh
 default completions/_rst2zsh
+build sections/river/software_versions.csv: versions | tools/generate_versions /var/lib/dpkg/status

--- a/sections/river/software_versions.csv
+++ b/sections/river/software_versions.csv
@@ -1,0 +1,8 @@
+"Package","Version"
+"|foot|","``1.23.1-1``"
+"|river|","``0.3.7+git41~gdfa10d8`` [#s1]_"
+"|river-tag-overlay|","``1.0.0+git16~g11d2dc4``"
+"|sandbar|","``0.1+git36~gf080371`` [#s2]_"
+"|swayidle|","``1.8.0-1``"
+"|wideriver|","``1.2.0+git35~g8c25ebf`` [#s2]_"
+"|wob|","``0.16+git14~g0a6ba9b``"

--- a/sections/river/software_versions.rst
+++ b/sections/river/software_versions.rst
@@ -1,17 +1,8 @@
 Software versions
 -----------------
 
-===================  ===============================
-Package              Version
-===================  ===============================
-|foot|               ``1.21.0``
-|river|              ``0.3.0+git91~g82cbe78`` [#s1]_
-|river-tag-overlay|  ``1.0.0+git16~g11d2dc4``
-|sandbar|            ``0.1+git36~gf080371`` [#s2]_
-|swayidle|           ``1.8.0``
-|wideriver|          ``1.2.0+git35~g8c25ebf`` [#s2]_
-|wob|                ``0.16+git14~g0a6ba9b``
-===================  ===============================
+.. csv-table::
+   :file: software_versions.csv
 
 .. note::
 

--- a/tools/generate_versions
+++ b/tools/generate_versions
@@ -1,0 +1,42 @@
+#!/bin/env zsh
+# This script generates a CSV file with software versions for use with
+# the csv-table directive in reStructuredText.
+
+setopt err_exit noclobber no_unset warn_create_global
+
+readonly output=$1
+
+readonly packages=(
+    foot
+    river
+    river-tag-overlay
+    sandbar
+    swayidle
+    wideriver
+    wob
+)
+
+# Associative array mapping commands to their footnote references.
+readonly -A footnotes=(
+    [river]=1
+    [sandbar]=2
+    [wideriver]=2
+)
+
+() {
+    readonly tmp=$1
+    local package version footnote
+    print '"Package","Version"' >> $tmp
+    for package ($packages) {
+        # At some point this won't be enough, but for now relying on dpkg-query
+        # Works For Me™
+        version=$(dpkg-query -W -f='${Version}' $package)
+
+        footnote=${footnotes[$package]:-}
+        if [[ $footnote ]] {
+            footnote=" [#s$footnote]_"
+        }
+        print "\"|$package|\",\"\`\`$version\`\`$footnote\"" >> $tmp
+    }
+    mv $tmp $output
+} =(:)


### PR DESCRIPTION
Manually updating the table is a pointless chore, but we’ll still need to keep a generated table in the tree to allow builds on GitHub to proceed.
