### PR TITLE
Limit GH actions runs by path

### DIFF
--- a/.github/workflows/build_HTML.yml
+++ b/.github/workflows/build_HTML.yml
@@ -1,6 +1,13 @@
 name: Generate and deploy HTML
 
-on: push
+on:
+  push:
+    paths:
+      - .github/workflows/build_HTML.yml
+      - .images/**
+      - conf.py
+      - requirements.txt
+      - "**.rst"
 
 permissions:
   contents: read

--- a/.github/workflows/extraction.yml
+++ b/.github/workflows/extraction.yml
@@ -1,6 +1,12 @@
 name: Test rst2zsh extraction
 
-on: push
+on:
+  push:
+    paths:
+      - .github/workflows/extraction.yml
+      - sections/rst2zsh/*.rst
+      - requirements.txt
+      - rst2zsh.rst
 
 permissions:
   contents: read

--- a/.github/workflows/rstlint.yml
+++ b/.github/workflows/rstlint.yml
@@ -1,6 +1,13 @@
 name: Lint reStructuredText files
 
-on: push
+on:
+  push:
+    paths:
+      - .github/workflows/rstlint.yml
+      - conf.py
+      - requirements.txt
+      - requirements-lint.txt
+      - "**.rst"
 
 permissions:
   contents: read

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,6 +1,12 @@
 name: Check spelling
 
-on: push
+on:
+  push:
+    paths:
+      - .github/workflows/spelling.yml
+      - conf.py
+      - requirements.txt
+      - "**.rst"
 
 permissions:
   contents: read


### PR DESCRIPTION
There was a fair few runs that were entirely unnecessary, and this
change *hopefully* narrows down the triggers for each workflow.

It is possible I haven’t quite got the triggers correct here, but a few
pushes should dispel that fear.
